### PR TITLE
Fijar versiones de paquetes en requirements.txt

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,6 @@
-fastapi
-fastf1
-uvicorn
-pyinstaller
-pandas
-scipy
+fastapi==0.111.*
+fastf1==3.3.*
+uvicorn==0.29.*
+pyinstaller==6.6.*
+pandas==2.2.*
+scipy==1.13.*


### PR DESCRIPTION
Fijar versiones de paquetes para evitar que se rompa la aplicación si alguna librería hace un breaking change